### PR TITLE
Skip localhost requests

### DIFF
--- a/force-ssl-heroku.js
+++ b/force-ssl-heroku.js
@@ -4,7 +4,8 @@ module.exports = function (req, res, next) {
   var sslUrl;
 
   if (process.env.NODE_ENV === 'production' &&
-    req.headers['x-forwarded-proto'] !== 'https') {
+    req.headers['x-forwarded-proto'] !== 'https' &&
+    req.hostname !== 'localhost') {
 
     sslUrl = ['https://', req.hostname, req.url].join('');
     return res.redirect(sslUrl);


### PR DESCRIPTION
In cases of server initiated requests, the request might already be targeted to localhost by the app, in which case it doesn't make sense to do the redirection.